### PR TITLE
Add option min_location_slots and use locality (town or city)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Use this repository as a custom repository in HACS.
 
 * locations (optional): a list of locations that are permanently visible, others are added/removed as required
 * exclude (optional): a list of locations that shall never be displayed, wizards at those locations will default to the `lost` state
+* min_location_slots (optional): the minimum number of locations to save space for around the dial of the clock 
 * wizards (required): a list of entities and display names for the device trackers/calendars used to represent your wizards. Now also supports setting individual colours for the hands/text.
 * fontname (required): the name of the font you want to use in the clock
 * fontface (optional): a fontface string to select a custom web-font to load
@@ -68,6 +69,7 @@ locations:
   - Home
   - Work
   - School
+min_location_slots: 5
 wizards:
   - entity: device_tracker.harrys_phone
     name: Harry


### PR DESCRIPTION
I've added some updates to my fork that you may be interested in:

- Option `min_location_slots` sets minimum number of slots to reserve around the dial. This makes it so that as locations pop in and out on the dial, the locations do not all slide around. (Optional because you may like the effect and having even spacing.)

- Accept `locality` attribute (if it exists) from the wizard tracker and use it as the location if Away and not in a Zone. (The `locality` is added by my `person_location` custom integration when it does reverse geocoding.)

- Show version in console log to make troubleshooting easier. Without it, you never know if Reload Resources has worked.)

- Update comments.